### PR TITLE
Remove quotes from AI generated commit messages

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -47,10 +47,10 @@ export function processChatCompletion(chatCompletion: any, useConventionalCommit
       return ''
 
     const contentJSON = JSON.parse(content) as CreateConventionalCommitOptions
-    return createConventionalCommit(contentJSON)
+    return removeQuotes(createConventionalCommit(contentJSON))
   }
   else {
-    return chatCompletion.choices[0].message?.content || ''
+    return removeQuotes(chatCompletion.choices[0].message?.content || '')
   }
 }
 
@@ -71,4 +71,8 @@ export function getGitInfo({ diff, changedLockfiles }: {
     gitInfo += `Changed lockfiles:${changedLockfiles.join(',')}`
 
   return gitInfo
+}
+
+export function removeQuotes(str: string): string {
+  return str.replace(/^"|"$/g, '')
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { checkLockfiles, createConventionalCommit, getChangedLinesNumber, getGitInfo, processChatCompletion } from '../src/pure'
+import { checkLockfiles, createConventionalCommit, getChangedLinesNumber, getGitInfo, processChatCompletion, removeQuotes } from '../src/pure'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -105,5 +105,28 @@ describe('getChangedLinesNumber Test', () => {
     const result = getChangedLinesNumber(stat)
 
     expect(result).toBe(22)
+  })
+})
+
+describe('removeQuotes Test', () => {
+  it('should remove quotes from the beginning and end of a string', () => {
+    const str = '"Hello, World!"'
+    const result = removeQuotes(str)
+
+    expect(result).toBe('Hello, World!')
+  })
+
+  it('should return the same string if there are no quotes', () => {
+    const str = 'Hello, World!'
+    const result = removeQuotes(str)
+
+    expect(result).toBe('Hello, World!')
+  })
+
+  it('should remove only the quotes at the beginning and end', () => {
+    const str = '"Hello, "World!"'
+    const result = removeQuotes(str)
+
+    expect(result).toBe('Hello, "World!')
   })
 })


### PR DESCRIPTION
Add functionality to remove quotes from AI-generated commit messages.

* **src/pure.ts**
  - Add `removeQuotes` function to remove quotes from the beginning and end of a string.
  - Update `processChatCompletion` function to call `removeQuotes` on the commit message.

* **test/extension.test.ts**
  - Add test cases for the `removeQuotes` function.
  - Update test cases for `processChatCompletion` to check for quotes removal.

